### PR TITLE
Bump OpenJDK version to v17 in a Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM openjdk:17-alpine
 
 # docker build -t jheinecke/conllueditor:2.16.1 .
 # docker build -t jheinecke/conllueditor:latest .


### PR DESCRIPTION
This prevents a java.lang.UnsupportedClassVersionError
(52 vs 55) when building the image on a current Arch.